### PR TITLE
add missing providers

### DIFF
--- a/KK.AspNetCore.EasyAuthAuthentication.code-workspace
+++ b/KK.AspNetCore.EasyAuthAuthentication.code-workspace
@@ -26,5 +26,9 @@
 			"path": "./"
 		}
 	],
-	"settings": {}
+	"settings": {
+		"cSpell.words": [
+			"authentification"
+		]
+	}
 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The last thing is to add the following section in the `appsettings.json` to enab
         "Enabled": true
       },
       {
-        "ProviderName": "EasyAuthWithHeaderService",
+        "ProviderName": "EasyAuthAzureAdService",
         "Enabled": true
       }
   ]
@@ -139,7 +139,7 @@ To configure you providers you simple add the following to your `appsettings.jso
         "RoleClaimType": "roles" // optional
       },
       {
-        "ProviderName": "EasyAuthWithHeaderService",
+        "ProviderName": "EasyAuthAzureAdService",
         "Enabled": true,
         "NameClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", //optional
         "RoleClaimType": "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" //optional
@@ -211,10 +211,28 @@ All providers can be configured with the following section in the `appsettings.j
         "RoleClaimType": "roles" // optional
       },
       {
-        "ProviderName": "EasyAuthWithHeaderService", // type name of the provider
-        "Enabled": true,
-        "NameClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", //optional
-        "RoleClaimType": "http://schemas.microsoft.com/ws/2008/06/identity/claims/role" //optional
+        "ProviderName": "EasyAuthForAuthorizationTokenService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthAzureAdService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthMicrosoftService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthFacebookService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthTwitterService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthGoogleService",
+        "Enabled": true
       }
     ],
     // the following is optional
@@ -272,9 +290,25 @@ To create a Service Principal (SPN), which get access to your EasyAuth protected
 
 This will allow a spn to get the role `SystemAdmin` in your protected application. The default `User.Identity.Name` of an SPN is the SPN Guid.
 
-### `EasyAuthWithHeaderService`
+### `EasyAuthAzureAdService`
 
 This is the most common auth provider. You can use it to work with Azure Active Directory Users in your easy auth application.
+
+### EasyAuthMicrosoftService
+
+If your users only has personal accounts because your app isn't a bushiness application, use this provider.
+
+### EasyAuthFacebookService
+
+If your users are primary come from facebook use this provider.
+
+### EasyAuthTwitterService
+
+If your users are primary come from twitter use this provider.
+
+### EasyAuthGoogleService
+
+If your users are primary come from twitter use this provider.
 
 ## Authors
 

--- a/samples/KK.AspNetCore.EasyAuthAuthentication.Samples.Web/KK.AspNetCore.EasyAuthAuthentication.Samples.Web.csproj
+++ b/samples/KK.AspNetCore.EasyAuthAuthentication.Samples.Web/KK.AspNetCore.EasyAuthAuthentication.Samples.Web.csproj
@@ -10,6 +10,7 @@
 
     <!-- Set this to true if you enable server-side prerendering -->
     <BuildServerSideRenderer>false</BuildServerSideRenderer>
+    <UserSecretsId>795deb04-f3bb-4d51-a58e-9d84a7b987fd</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/KK.AspNetCore.EasyAuthAuthentication.Samples.Web/appsettings.json
+++ b/samples/KK.AspNetCore.EasyAuthAuthentication.Samples.Web/appsettings.json
@@ -15,7 +15,23 @@
         "Enabled": true
       },
       {
-        "ProviderName": "EasyAuthWithHeaderService",
+        "ProviderName": "EasyAuthAzureAdService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthMicrosoftService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthFacebookService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthTwitterService",
+        "Enabled": true
+      },
+      {
+        "ProviderName": "EasyAuthGoogleService",
         "Enabled": true
       }
     ]

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Models/ProviderOptions.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Models/ProviderOptions.cs
@@ -27,7 +27,7 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Models
         public ProviderOptions(string providerName, string nameClaimType)
         {
             this.ProviderName = providerName;
-            this.NameClaimType = nameClaimType;            
+            this.NameClaimType = nameClaimType;
         }
 
         /// <summary>
@@ -41,20 +41,20 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Models
         {
             this.ProviderName = providerName;
             this.NameClaimType = nameClaimType;
-            this.RoleClaimType  = roleNameClaimType;
+            this.RoleClaimType = roleNameClaimType;
         }
 
         /// <summary>
         /// The <c>ClaimType</c> for the Idendity User.
         /// </summary>
         /// <value>The Claim Type to use for the User. Default is <c>ClaimType</c> of the auth provider.</value>
-        public string NameClaimType { get; set; } = ClaimTypes.Name;
+        public string NameClaimType { get; set; } = string.Empty;
 
         /// <summary>
         /// The <c>ClaimType</c> for the Idendity Role.
         /// </summary>
         /// <value>The Claim Type to use for the Roles. Default is <c>ClaimType</c> of the auth provider.</value>
-        public string RoleClaimType { get; set; } = ClaimTypes.Role;
+        public string RoleClaimType { get; set; } = string.Empty;
 
         /// <summary>
         /// The provider name for this options object.
@@ -71,7 +71,7 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Models
         /// </summary>
         /// <param name="options">The provider options model with the new options.</param>
         public void ChangeModel(ProviderOptions? options)
-        {            
+        {
             if (options == null)
             {
                 return;

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthAzureAdService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthAzureAdService.cs
@@ -1,0 +1,34 @@
+namespace KK.AspNetCore.EasyAuthAuthentication.Services
+{
+    using System.Security.Claims;
+    using KK.AspNetCore.EasyAuthAuthentication.Interfaces;
+    using KK.AspNetCore.EasyAuthAuthentication.Models;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+
+    public class EasyAuthAzureAdService: EasyAuthWithHeaderService<EasyAuthAzureAdService>, IEasyAuthAuthentificationService
+    {
+        private readonly ILogger<EasyAuthAzureAdService> logger;
+
+        public EasyAuthAzureAdService(ILogger<EasyAuthAzureAdService> logger) : base(logger)
+        {
+            this.logger = logger;
+            this.defaultOptions = new ProviderOptions(typeof(EasyAuthAzureAdService).Name, "name", ClaimTypes.Role);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context)
+        {
+            this.logger.LogInformation("Try authentification with azure ad account.");
+            return base.AuthUser(context);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context, ProviderOptions options)
+        {
+            this.logger.LogInformation("Try authentification with azure ad account.");
+            return base.AuthUser(context, options);
+        }
+
+        public new bool CanHandleAuthentification(HttpContext httpContext) => base.CanHandleAuthentification(httpContext) && httpContext.Request.Headers[PrincipalIdpHeaderName] == "aad" && IsHeaderSet(httpContext.Request.Headers, AuthTokenHeaderNames.AADIdToken);
+    }
+}

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthFacebookService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthFacebookService.cs
@@ -1,0 +1,32 @@
+namespace KK.AspNetCore.EasyAuthAuthentication.Services
+{
+    using System.Security.Claims;
+    using KK.AspNetCore.EasyAuthAuthentication.Interfaces;
+    using KK.AspNetCore.EasyAuthAuthentication.Models;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+
+    public class EasyAuthFacebookService : EasyAuthWithHeaderService<EasyAuthFacebookService>, IEasyAuthAuthentificationService
+    {
+        private readonly ILogger<EasyAuthFacebookService> logger;
+        public EasyAuthFacebookService(ILogger<EasyAuthFacebookService> logger) : base(logger){
+            this.logger = logger;
+            this.defaultOptions = new ProviderOptions(typeof(EasyAuthFacebookService).Name, "name", ClaimTypes.Role);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context)
+        {
+            this.logger.LogInformation("Try authentification with facebook account.");
+            return base.AuthUser(context);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context, ProviderOptions options)
+        {
+            this.logger.LogInformation("Try authentification with facebook account.");
+            return base.AuthUser(context, options);
+        }
+
+        public new bool CanHandleAuthentification(HttpContext httpContext) => base.CanHandleAuthentification(httpContext) && httpContext.Request.Headers[PrincipalIdpHeaderName] == "facebook" && IsHeaderSet(httpContext.Request.Headers, AuthTokenHeaderNames.FacebookAccessToken);
+    }
+}

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthGoogleService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthGoogleService.cs
@@ -1,0 +1,33 @@
+namespace KK.AspNetCore.EasyAuthAuthentication.Services
+{
+    using System.Security.Claims;
+    using KK.AspNetCore.EasyAuthAuthentication.Interfaces;
+    using KK.AspNetCore.EasyAuthAuthentication.Models;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+
+    public class EasyAuthGoogleService : EasyAuthWithHeaderService<EasyAuthGoogleService>, IEasyAuthAuthentificationService
+    {
+        private readonly ILogger<EasyAuthGoogleService> logger;
+        public EasyAuthGoogleService(ILogger<EasyAuthGoogleService> logger) : base(logger)
+        {
+            this.logger = logger;
+            this.defaultOptions = new ProviderOptions(typeof(EasyAuthGoogleService).Name, "name", ClaimTypes.Role);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context)
+        {
+            this.logger.LogInformation("Try authentification with google account.");
+            return base.AuthUser(context);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context, ProviderOptions options)
+        {
+            this.logger.LogInformation("Try authentification with google account.");
+            return base.AuthUser(context, options);
+        }
+
+        public new bool CanHandleAuthentification(HttpContext httpContext) => base.CanHandleAuthentification(httpContext) && httpContext.Request.Headers[PrincipalIdpHeaderName] == "google" && IsHeaderSet(httpContext.Request.Headers, AuthTokenHeaderNames.GoogleIdToken);
+    }
+}

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthMicrosoftService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthMicrosoftService.cs
@@ -1,0 +1,34 @@
+namespace KK.AspNetCore.EasyAuthAuthentication.Services
+{
+    using System.Security.Claims;
+    using KK.AspNetCore.EasyAuthAuthentication.Interfaces;
+    using KK.AspNetCore.EasyAuthAuthentication.Models;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+
+    public class EasyAuthMicrosoftService : EasyAuthWithHeaderService<EasyAuthMicrosoftService>, IEasyAuthAuthentificationService
+    {
+        private readonly ILogger<EasyAuthMicrosoftService> logger;
+
+        public EasyAuthMicrosoftService(ILogger<EasyAuthMicrosoftService> logger) : base(logger)
+        {
+            this.logger = logger;
+            this.defaultOptions = new ProviderOptions(typeof(EasyAuthMicrosoftService).Name, "name", ClaimTypes.Role);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context)
+        {
+            this.logger.LogInformation("Try authentification with microsoft account.");
+            return base.AuthUser(context);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context, ProviderOptions options)
+        {
+            this.logger.LogInformation("Try authentification with microsoft account.");
+            return base.AuthUser(context, options);
+        }
+
+        public new bool CanHandleAuthentification(HttpContext httpContext) => base.CanHandleAuthentification(httpContext) && httpContext.Request.Headers[PrincipalIdpHeaderName] == "microsoftaccount" && IsHeaderSet(httpContext.Request.Headers, AuthTokenHeaderNames.MicrosoftAccessToken);
+    }
+}

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthTwitterService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthTwitterService.cs
@@ -1,0 +1,34 @@
+namespace KK.AspNetCore.EasyAuthAuthentication.Services
+{
+    using System.Security.Claims;
+    using KK.AspNetCore.EasyAuthAuthentication.Interfaces;
+    using KK.AspNetCore.EasyAuthAuthentication.Models;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+
+    public class EasyAuthTwitterService : EasyAuthWithHeaderService<EasyAuthTwitterService>, IEasyAuthAuthentificationService
+    {
+        private readonly ILogger<EasyAuthTwitterService> logger;
+
+        public EasyAuthTwitterService(ILogger<EasyAuthTwitterService> logger) : base(logger)
+        {
+            this.logger = logger;
+            this.defaultOptions = new ProviderOptions(typeof(EasyAuthTwitterService).Name, "name", ClaimTypes.Role);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context)
+        {
+            this.logger.LogInformation("Try authentification with twitter account.");
+            return base.AuthUser(context);
+        }
+
+        public new AuthenticateResult AuthUser(HttpContext context, ProviderOptions options)
+        {
+            this.logger.LogInformation("Try authentification with twitter account.");
+            return base.AuthUser(context, options);
+        }
+
+        public new bool CanHandleAuthentification(HttpContext httpContext) => base.CanHandleAuthentification(httpContext) && httpContext.Request.Headers[PrincipalIdpHeaderName] == "twitter" && IsHeaderSet(httpContext.Request.Headers, AuthTokenHeaderNames.TwitterAccessToken);
+    }
+}

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthWithHeaderService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthWithHeaderService.cs
@@ -15,35 +15,39 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Services
     /// <summary>
     /// A service that can be used to authentificat a user principal in the <see cref="EasyAuthAuthenticationHandler"/>.
     /// </summary>
-    public class EasyAuthWithHeaderService : IEasyAuthAuthentificationService
+    public abstract class EasyAuthWithHeaderService<T> : IEasyAuthAuthentificationService where T : IEasyAuthAuthentificationService
     {
         private const string PrincipalObjectHeader = "X-MS-CLIENT-PRINCIPAL";
-        private const string PrincipalIdpHeaderName = "X-MS-CLIENT-PRINCIPAL-IDP";
+        protected const string PrincipalIdpHeaderName = "X-MS-CLIENT-PRINCIPAL-IDP";
 
         private static readonly Func<ClaimsPrincipal, bool> IsContextUserNotAuthenticated =
             user => user == null || user.Identity == null || user.Identity.IsAuthenticated == false;
 
-        private static readonly Func<IHeaderDictionary, string, bool> IsHeaderSet =
+        protected static readonly Func<IHeaderDictionary, string, bool> IsHeaderSet =
             (headers, headerName) => !string.IsNullOrEmpty(headers[headerName].ToString());
 
-        private readonly ProviderOptions defaultOptions = new ProviderOptions(typeof(EasyAuthWithHeaderService).Name, ClaimTypes.Email, ClaimTypes.Role);
+#pragma warning disable IDE1006 // Naming Styles rule is broken
+        protected ProviderOptions defaultOptions = new ProviderOptions(typeof(T).Name, ClaimTypes.Email, ClaimTypes.Role);
+#pragma warning restore IDE1006 // Naming Styles
+
+
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EasyAuthWithHeaderService"/> class.
         /// </summary>
         /// <param name="logger">The logger for this service.</param>
         public EasyAuthWithHeaderService(
-            ILogger<EasyAuthWithHeaderService> logger) => this.Logger = logger;
+            ILogger<EasyAuthWithHeaderService<T>> logger) => this.Logger = logger;
 
-        private ILogger Logger { get; }
+        protected ILogger Logger { get; }
 
         /// <inheritdoc/>
         public bool CanHandleAuthentification(HttpContext httpContext)
         {
             var headers = httpContext.Request.Headers;
             var user = httpContext.User;
-            return IsContextUserNotAuthenticated(user) &&
-                IsHeaderSet(headers, AuthTokenHeaderNames.AADIdToken);
+            return IsContextUserNotAuthenticated(user);
+                
         }
 
         /// <summary>

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/LocalAuthMeService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/LocalAuthMeService.cs
@@ -2,7 +2,6 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Services
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Security.Claims;

--- a/test/KK.AspNetCore.EasyAuthAuthentication.Test/Services/EasyAuthWithHeaderServiceTest.cs
+++ b/test/KK.AspNetCore.EasyAuthAuthentication.Test/Services/EasyAuthWithHeaderServiceTest.cs
@@ -53,7 +53,7 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Test.Services
                 Claims = new List<InputClaims>()
                 {
                     new InputClaims() {Typ=  "x", Value= "y"},
-                    new InputClaims() {Typ=  ClaimTypes.Email, Value= "PrincipalName"},
+                    new InputClaims() {Typ=  "name", Value= "PrincipalName"},
                     new InputClaims() {Typ = ClaimTypes.Role, Value = "Admin"}
                 }
             };

--- a/test/KK.AspNetCore.EasyAuthAuthentication.Test/Services/EasyAuthWithHeaderServiceTest.cs
+++ b/test/KK.AspNetCore.EasyAuthAuthentication.Test/Services/EasyAuthWithHeaderServiceTest.cs
@@ -20,9 +20,10 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Test.Services
         public void IfTheAADIdTokenHeaderIsSetTheCanUseMethodMustReturnTrue()
         {
             // Arrange
-            var handler = new EasyAuthWithHeaderService(this.loggerFactory.CreateLogger<EasyAuthWithHeaderService>());
+            var handler = new EasyAuthAzureAdService(this.loggerFactory.CreateLogger<EasyAuthAzureAdService>());
             var httpcontext = new DefaultHttpContext();
             httpcontext.Request.Headers.Add("X-MS-TOKEN-AAD-ID-TOKEN", "blup");
+            httpcontext.Request.Headers.Add("X-MS-CLIENT-PRINCIPAL-IDP", "aad");
             // Act
             var result = handler.CanHandleAuthentification(httpcontext);
             // Arrange
@@ -33,7 +34,7 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Test.Services
         public void IfTheAuthorizationHeaderIsNotSetTheCanUseMethodMustReturnFalse()
         {
             // Arrange
-            var handler = new EasyAuthWithHeaderService(this.loggerFactory.CreateLogger<EasyAuthWithHeaderService>());
+            var handler = new EasyAuthAzureAdService(this.loggerFactory.CreateLogger<EasyAuthAzureAdService>());
             var httpcontext = new DefaultHttpContext();
             // Act
             var result = handler.CanHandleAuthentification(httpcontext);
@@ -45,7 +46,7 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Test.Services
         public void IfAValidJwtTokenIsInTheHeaderTheResultIsSuccsess()
         {
             // Arrange
-            var handler = new EasyAuthWithHeaderService(this.loggerFactory.CreateLogger<EasyAuthWithHeaderService>());
+            var handler = new EasyAuthAzureAdService(this.loggerFactory.CreateLogger<EasyAuthAzureAdService>());
             var httpcontext = new DefaultHttpContext();
             var inputObject = new InputJson()
             {


### PR DESCRIPTION
Add all the missing providers. This is working but has an breaking change. You must change your configuration. There isn't a `EasyAuthWithHeaderService` provider anymore. There are now some new ones:

- `EasyAuthAzureAdService`
- `EasyAuthMicrosoftService`
- `EasyAuthTwitterService` 
- `EasyAuthGoogleService`
- `EasyAuthFacebookService`

Maybe also @tinomager want to review this. This only enable us to provide the user informations to the application for each IDP. This is currently not the solution to have multiple IDPs enabled in easy auth. we take care in another version.

closes #38 