### PR TITLE
Add fallback to "sub" claim in access token for NameClaim

### DIFF
--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthForAuthorizationTokenService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/EasyAuthForAuthorizationTokenService.cs
@@ -84,13 +84,30 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Services
                 .Select(claimToken => new AADClaimsModel { Typ = claimToken.Name, Values = claimToken.Value.ToString() })
                 .ToList();
             claims.AddRange(otherClaims);
+
+            string nameClaimValue;
+            if (xMsClientPrincipal.ContainsKey("upn")) // AAD "upn" user auth claim
+            {
+                nameClaimValue = xMsClientPrincipal["upn"].ToString();
+            }
+            else if (xMsClientPrincipal.ContainsKey("appid")) // AAD "appid" application auth claim
+            {
+                nameClaimValue = xMsClientPrincipal["appid"].ToString();
+            }
+            else if (xMsClientPrincipal.ContainsKey("sub")) // JWT standard "sub"ject claim
+            {
+                nameClaimValue = xMsClientPrincipal["sub"].ToString();
+            }
+            else
+            {
+                throw new ArgumentException("Provided JWT token is missing a subject, user ID, or app ID claim", nameof(xMsClientPrincipal));
+            }
             claims.Add(new AADClaimsModel
             {
                 Typ = options.NameClaimType,
-                Values = xMsClientPrincipal.ContainsKey("upn") ?
-                    xMsClientPrincipal["upn"].ToString() : // this appends if an user is using the auth token from the /.auth/me site on the website
-                    xMsClientPrincipal["appid"].ToString() // this appends if an applicaiton is try accessing the app.
+                Values = nameClaimValue
             });
+
             return claims;
         }
 

--- a/test/KK.AspNetCore.EasyAuthAuthentication.Test/Services/EasyAuthForAuthorizationTokenServiceTest.cs
+++ b/test/KK.AspNetCore.EasyAuthAuthentication.Test/Services/EasyAuthForAuthorizationTokenServiceTest.cs
@@ -15,6 +15,9 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Test.Services
         private readonly ILoggerFactory loggerFactory = new NullLoggerFactory();
         private readonly string testJwt = @"Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IkN0ZlFDOExlLThOc0M3b0MyelFrWnBjcmZPYyIsImtpZCI6IkN0ZlFDOExlLThOc0M3b0MyelFrWnBjcmZPYyJ9.eyJhdWQiOiIwN2Q2ZDE1YS1jZTg5LTQ4MmMtOTcxYi01NDMxYjc1MTkxNjciLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9lOTgxZGNhZi05MTk3LTQ3N2YtYmQwNi0wZTU3MmIwYjMzNDcvIiwiaWF0IjoxNTYyNjk4ODc2LCJuYmYiOjE1NjI2OTg4NzYsImV4cCI6MTU2MjcwMjc3NiwiYWlvIjoiNDJaZ1lPQmZzRzd0ZEg1ZVBpSHZvNU9QdDdyT0J3QT0iLCJhcHBpZCI6ImQzMTViZmFmLTYzMDQtNGY5Zi04MjFjLTU0NmJkYzAwYjViMCIsImFwcGlkYWNyIjoiMSIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0L2U5ODFkY2FmLTkxOTctNDc3Zi1iZDA2LTBlNTcyYjBiMzM0Ny8iLCJvaWQiOiJmNWY5ZmE4Ni00NDE0LTQ0YzctODBmOC1mNzgwYWUwYWJmMjEiLCJyb2xlcyI6WyJTeXN0ZW1BZG1pbiJdLCJzdWIiOiJmNWY5ZmE4Ni00NDE0LTQ0YzctODBmOC1mNzgwYWUwYWJmMjEiLCJ0aWQiOiJlOTgxZGNhZi05MTk3LTQ3N2YtYmQwNi0wZTU3MmIwYjMzNDciLCJ1dGkiOiJoQ0p1M29oN3dVZVphaTVRSk9ZQUFBIiwidmVyIjoiMS4wIn0.fni_mCHCFWVXn1RtOvTWC5OgNU3xD_xyG38Bc1BfdcdoWP1p2N69HsW76rkk-IruDMdsiJaYKekK6RwUbBvbYii_S-fcT1FbdXCtYdFWm892Z4VGk8UFmS5HIApJd6WK4iHHwBv_R8n2juXyHKWfpZNaOldgaU0bRePSe3wu9_ZGOZ5et0_bbs1Y0UrwgaycZWwBSkah5s7fnLRBtMXmsEQlWPqnEzvwjieoqYs-YIndvau39ZE_0HT55kpbgE2HFJ2E62jyzJnMf60l8LlA_aXN6naNNm-SBepDoWVkUjZ-uQZbAdAr-MS-BIP4wS-1jrOvAfD6m7qOVcDaGYIv5A";
         private readonly string testJwtAppId = "d315bfaf-6304-4f9f-821c-546bdc00b5b0";
+        // Extremely simple JWT with very few claims: no roles claim, only NameIdentifier claim is the "sub" claim (no "upn" or "appid" claim)
+        private readonly string testJwtSimple = @"Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGViMmMuYjJjbG9naW4uY29tLzg1NmJhZGNlLTUwZjEtNDhlNC05MWIyLTZjYzExZTdkYTFlMi92Mi4wLyIsImV4cCI6MTU5ODA0NjY0NywibmJmIjoxNTk4MDQzMDQ3LCJhdWQiOiJlYmY1YzIyYi05YTk1LTQwYmItOGU2YS0zYTM5OWRmNTE0YTEiLCJzdWIiOiIxMWY0NWUwNy1iMmZlLTQ2OWQtYTQyZS02ZmJkOGNiZWQ1NTgiLCJuYW1lIjoiVGVzdCBVc2VyIiwiZW1haWxzIjpbInRlc3RAZXhhbXBsZS5jb20iXSwidGZwIjoiQjJDXzFfU2lnbnVwU2lnbmluIiwibm9uY2UiOiJmYjE4NDg4YzQxOTg0MTM4ODkyYzMwYWY1OWY3YWNlOV8yMDIwMDgyMTIwNTUyNyIsInNjcCI6InJlYWQiLCJhenAiOiJlYmY1YzIyYi05YTk1LTQwYmItOGU2YS0zYTM5OWRmNTE0YTEiLCJ2ZXIiOiIxLjAiLCJpYXQiOjE1OTgwNDMwNDd9.2u4GOF8V_dTKMYOehg4HQHbe5-S0KCsnSBoecrBBeiU";
+        private readonly string testJwtUserId = "11f45e07-b2fe-469d-a42e-6fbd8cbed558";
 
         [Fact]
         public void IfTheAuthorizationHeaderIsSetTheCanUseMethodMustReturnTrue()
@@ -67,6 +70,20 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Test.Services
             Assert.True(result.Succeeded);
             Assert.True(result.Principal.HasClaim(ClaimTypes.Role, "SystemAdmin"));
             Assert.Equal(this.testJwtAppId, result.Principal.Identity.Name);
+        }
+
+        [Fact]
+        public void IfAValidButVeryBasicJwtTokenIsInTheHeaderTheResultIsSuccess()
+        {
+            // Arrange
+            var handler = new EasyAuthForAuthorizationTokenService(this.loggerFactory.CreateLogger<EasyAuthForAuthorizationTokenService>());
+            var httpcontext = new DefaultHttpContext();
+            httpcontext.Request.Headers.Add("Authorization", this.testJwtSimple);
+            // Act
+            var result = handler.AuthUser(httpcontext);
+            // Arrange
+            Assert.True(result.Succeeded);
+            Assert.Equal(this.testJwtUserId, result.Principal.Identity.Name);
         }
 
         [Fact]


### PR DESCRIPTION
Another case where I'm seeing slightly different access tokens (presumably because these are from B2C) and the only name claim in the access tokens is the the standard "sub" claim (no "upn" or "appid" claim). This fixes a NullReferenceException similar to #52.