### PR TITLE
Log name and role claims as information, when running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The result of the request is a json with the authentication information of your 
 If you want to add roles to the `User` property you can have a look in `Transformers/ClaimsTransformer.cs` in the Sample project. There you can see an example how to get started with this.
 
 ### Adding App Roles and receiving them in the token
+
 Azure AD supports [adding custom App Roles](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps) to your application manifest, assigning users or groups to the App Roles and [receiving user membership (direct or via groups) in the token as `roles` claims](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps#receive-roles-in-tokens).
 
 When you've extended your app manifest with your App Roles, you will see the `roles` claims appear in the token when requesting the Azure URL: `https://yourAzureAppServiceUrl/.auth/me`

--- a/README.md
+++ b/README.md
@@ -120,6 +120,40 @@ The result of the request is a json with the authentication information of your 
 
 If you want to add roles to the `User` property you can have a look in `Transformers/ClaimsTransformer.cs` in the Sample project. There you can see an example how to get started with this.
 
+### Adding App Roles and receiving them in the token
+Azure AD supports [adding custom App Roles](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps) to your application manifest, assigning users or groups to the App Roles and [receiving user membership (direct or via groups) in the token as `roles` claims](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps#receive-roles-in-tokens).
+
+When you've extended your app manifest with your App Roles, you will see the `roles` claims appear in the token when requesting the Azure URL: `https://yourAzureAppServiceUrl/.auth/me`
+
+They'll appear like this:
+
+```json
+     {
+        "typ":"roles",
+        "val":"Test_Reader"
+     },
+     {
+        "typ":"roles",
+        "val":"Test_Admin"
+     },
+     {
+        "typ":"roles",
+        "val":"Test_Expert"
+     },
+```
+
+If they do not appear, it is possibly because the logged in user is not assigned to any of the App Roles, via group or direct membership.
+
+**Important note**: When using this approach and debugging locally, you must configure the `LocalAuthMeService` to use `roles` as claim type for appending the roles to the `AuthenticationTicket`.
+
+Add the following to `appsettings.json` inside the `easyAuthOptions` property:
+
+```json
+    "localProviderOption": {
+        "RoleClaimType": "roles"
+    }
+```
+
 ### Configure options via configuration (recommended)
 
 You can use the default behavior of asp.net core to configure EasyAuth. You must only change in your `Startup.cs` the `.AddEasyAuth()` to `.AddEasyAuth(this.Configuration)`.

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/LocalAuthMeService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/LocalAuthMeService.cs
@@ -87,7 +87,6 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Services
         private AuthenticationTicket BuildIdentityFromEasyAuthMeJson(JObject payload)
         {
             var providerName = payload["provider_name"].Value<string>();
-            var providerOptions = this.defaultOptions.GetProviderOptions();
 
             this.Logger.LogDebug($"payload was fetched from easyauth me json, provider: {providerName}");
 
@@ -95,11 +94,11 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Services
             var ticket = AuthenticationTicketBuilder.Build(
                     JsonConvert.DeserializeObject<IEnumerable<AADClaimsModel>>(payload["user_claims"].ToString()),
                     providerName,
-                    providerOptions
+                    this.defaultOptions.GetProviderOptions()
                 );
 
-            var name = ticket.Principal.Claims?.FirstOrDefault(c => c.Type == providerOptions.NameClaimType)?.Value ?? string.Empty;
-            var roles = ticket.Principal.Claims?.Where(c => c.Type == providerOptions.RoleClaimType);
+            var name = ticket.Principal.Claims?.FirstOrDefault(c => c.Type == ClaimTypes.Name)?.Value ?? string.Empty;
+            var roles = ticket.Principal.Claims?.Where(c => c.Type == ClaimTypes.Role);
             var rolesString = string.Join(", ", roles.Select(r => r.Value)) ?? string.Empty;
 
             this.Logger.LogInformation($"identity name: '{ name }' with roles: [{ rolesString }]");

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/LocalAuthMeService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/LocalAuthMeService.cs
@@ -99,7 +99,7 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Services
 
             var name = ticket.Principal.Claims?.FirstOrDefault(c => c.Type == ClaimTypes.Name)?.Value ?? string.Empty;
             var roles = ticket.Principal.Claims?.Where(c => c.Type == ClaimTypes.Role);
-            var rolesString = string.Join(", ", roles.Select(r => r.Value)) ?? string.Empty;
+            var rolesString = string.Join(", ", roles?.Select(r => r.Value)) ?? string.Empty;
 
             this.Logger.LogInformation($"identity name: '{ name }' with roles: [{ rolesString }]");
 

--- a/src/KK.AspNetCore.EasyAuthAuthentication/Services/LocalAuthMeService.cs
+++ b/src/KK.AspNetCore.EasyAuthAuthentication/Services/LocalAuthMeService.cs
@@ -98,10 +98,11 @@ namespace KK.AspNetCore.EasyAuthAuthentication.Services
                     providerOptions
                 );
 
-            var name = ticket.Principal.Claims.FirstOrDefault(c => c.Type == providerOptions.NameClaimType);
-            var roles = ticket.Principal.Claims.Where(c => c.Type == providerOptions.RoleClaimType);
+            var name = ticket.Principal.Claims?.FirstOrDefault(c => c.Type == providerOptions.NameClaimType)?.Value ?? string.Empty;
+            var roles = ticket.Principal.Claims?.Where(c => c.Type == providerOptions.RoleClaimType);
+            var rolesString = string.Join(", ", roles.Select(r => r.Value)) ?? string.Empty;
 
-            this.Logger.LogInformation($"identity name: '{name?.Value ?? "" }' with roles: [{ string.Join(", ", roles.Select(r => r.Value)) }]");
+            this.Logger.LogInformation($"identity name: '{ name }' with roles: [{ rolesString }]");
 
             return ticket;
         }


### PR DESCRIPTION
We're using custom App Roles in our application: https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps

Users are granted membership of App Roles in Azure AD, and the membership appears as `roles` claims in the token:

```
         {
            "typ":"roles",
            "val":"Test_Reader"
         },
         {
            "typ":"roles",
            "val":"Test_Admin"
         },
         {
            "typ":"roles",
            "val":"Test_Expert"
         },
```

We had some issues after upgrading this package with new configuration, and it wasn't immediately evident what was missing, as the authentication part itself worked fine, but Authorization via `AuthorizeAttribute` in controllers failed, as we had required roles: `[Authorize(Roles = "Test_Expert")]`

First of all, I've added description of App Roles to the readme to inform about the need to override the claims type of the roles claims, to find the App Roles claims in the token.

Second, I've added more logging to `LocalAuthMeService` to inform about the name and roles claims found in the JSON payload. This would've been helpful to see in the console, to clearly see what goes inside the `AuthenticationTicket` parsed from the JSON payload.